### PR TITLE
Add missing link to /sign-in

### DIFF
--- a/components/sign-up/SignUpModal.tsx
+++ b/components/sign-up/SignUpModal.tsx
@@ -16,6 +16,14 @@ const SignUpModal = () => {
         <GoogleButton>
           Continue with Google
         </GoogleButton>
+        <div className='flex justify-center py-3'>
+          <a
+            className='font-montserrat font-semibold text-[14px] underline leading-[24px]'
+            href="/sign-in"
+          >
+            I already have an account!
+          </a>
+        </div>
       </div>
     </div>
   )

--- a/components/sign-up/SignUpModal.tsx
+++ b/components/sign-up/SignUpModal.tsx
@@ -18,7 +18,7 @@ const SignUpModal = () => {
         </GoogleButton>
         <div className='flex justify-center py-3'>
           <a
-            className='font-montserrat font-semibold text-[14px] underline leading-[24px]'
+            className='font-montserrat font-semibold text-[14px] text-[#212925] underline leading-[24px]'
             href="/sign-in"
           >
             I already have an account!


### PR DESCRIPTION
Sign-up modal was missing the "I already have an account!" link to direct user to /login

Before:
<img width="504" alt="image" src="https://github.com/v-sudo29/great-reads/assets/117846985/554819a4-58b0-46d5-a50f-14aa722924a2">

After:
<img width="488" alt="image" src="https://github.com/v-sudo29/great-reads/assets/117846985/5cf9a33b-3992-4fed-a5ad-53918f4814c4">
