### PR TITLE
Update z-index of SignInModal, remove outer div container

### DIFF
--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -30,9 +30,7 @@ const SignIn = () => {
         <div className='pointer-events-none flex justify-center w-full'>
           <Home />
         </div>
-        <div className='z-50'>
-          <SignInModal/>
-        </div>
+        <SignInModal/>
       </div>
     </>
   )

--- a/components/nav/MobileSidebar.tsx
+++ b/components/nav/MobileSidebar.tsx
@@ -8,9 +8,6 @@ import ExploreIcon from "@components/common/icons/ExploreIcon"
 import SettingsIcon from "@components/common/icons/SettingsIcon"
 import { IBook } from "@customTypes/bookType"
 import SidebarNavLink from "./SidebarNavLink"
-import { useState } from "react"
-import CreateListModal from "./CreateListModal"
-import Overlay from "@components/common/Overlay"
 
 interface MobileSidebarProps {
   isMobileSidebarOpen: boolean

--- a/components/sign-in/SignInModal.tsx
+++ b/components/sign-in/SignInModal.tsx
@@ -4,7 +4,7 @@ import ExitIcon from "@components/common/icons/ExitIcon"
 
 const SignInModal = () => {
   return (
-    <div className='absolute flex justify-center w-full h-full px-4 xl:fixed xl:top-0 xl:left-0'>
+    <div className='absolute z-50 flex justify-center w-full h-full px-4 xl:fixed xl:top-0 xl:left-0'>
       <div className='relative mt-[6.5rem] flex flex-col w-full h-max max-w-[480px] gap-3 px-4 py-5 bg-white shadow-xl rounded-xl xl:mt-auto xl:mb-auto xl:p-6'>
         <a 
           href='/'


### PR DESCRIPTION
Issue: SignInModal wasn't being displayed at mobile breakpoint

Before:
<img width="928" alt="image" src="https://github.com/v-sudo29/great-reads/assets/117846985/9e53c670-9b00-4610-b134-d35928d93e25">

After:
<img width="939" alt="image" src="https://github.com/v-sudo29/great-reads/assets/117846985/448f7af4-2739-4941-b9e4-a7ce2b35a024">
