### PR TITLE
Fix mobile padding for /home

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default function Home() {
       {/* Authenticated UI */}
       {session && (
         <section className="px-3 xl:py-10 xl:px-12 xl:flex">
-          <div className="pr-[104px]">
+          <div className="xl:pr-[104px]">
             <h1 className="hidden font-lora font-bold text-[24px] text-primary leading-[60px] mb-4 xl:block">
               Latest Updates
             </h1>


### PR DESCRIPTION
Before:
<img width="671" alt="image" src="https://github.com/v-sudo29/great-reads/assets/117846985/4d9142fc-7b16-41e6-9dcb-29307e004160">

After:
<img width="495" alt="image" src="https://github.com/v-sudo29/great-reads/assets/117846985/fb3ffa5d-ea31-4b4f-aa1c-c7156823092f">
